### PR TITLE
Shellcheck raises SC2086 warnings over the use of unquoted variables

### DIFF
--- a/git-stats.sh
+++ b/git-stats.sh
@@ -37,12 +37,12 @@ do
     echo '-------------------'
     echo "Statistics for: $a"
     echo -n "Number of files changed: "
-    git log "${LOGOPTS[@]}" "${END_AND_BEGIN[@]}" --all --numstat --format="%n" --author=$a | grep -v -e "^$" | cut -f3 | sort -iu | wc -l
+    git log "${LOGOPTS[@]}" "${END_AND_BEGIN[@]}" --all --numstat --format="%n" --author="$a" | grep -v -e "^$" | cut -f3 | sort -iu | wc -l
     echo -n "Number of lines added: "
-    git log "${LOGOPTS[@]}" "${END_AND_BEGIN[@]}" --all --numstat --format="%n" --author=$a | cut -f1 | awk '{s+=$1} END {print s}'
+    git log "${LOGOPTS[@]}" "${END_AND_BEGIN[@]}" --all --numstat --format="%n" --author="$a" | cut -f1 | awk '{s+=$1} END {print s}'
     echo -n "Number of lines deleted: "
-    git log "${LOGOPTS[@]}" "${END_AND_BEGIN[@]}" --all --numstat --format="%n" --author=$a | cut -f2 | awk '{s+=$1} END {print s}'
+    git log "${LOGOPTS[@]}" "${END_AND_BEGIN[@]}" --all --numstat --format="%n" --author="$a" | cut -f2 | awk '{s+=$1} END {print s}'
     echo -n "Number of merges: "
-    git log "${LOGOPTS[@]}" "${END_AND_BEGIN[@]}" --all --merges --author=$a | grep -c '^commit'
+    git log "${LOGOPTS[@]}" "${END_AND_BEGIN[@]}" --all --merges --author="$a" | grep -c '^commit'
 
 done

--- a/git-stats.sh
+++ b/git-stats.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 LOGOPTS=()
-END_AND_BEGIN=
+END_AND_BEGIN=()
 #argument parsing
 while [ -n "$1" ]; do
     case "$1" in
      "-s")
         shift
-        END_AND_BEGIN="$END_AND_BEGIN --after=$1"
+        END_AND_BEGIN+=("--after=$1")
     ;;
     "-e")
         shift
-        END_AND_BEGIN="$END_AND_BEGIN --before=$1"
+        END_AND_BEGIN+=("--before=$1")
     ;;
     "-w")
         LOGOPTS+=("-w")
@@ -29,20 +29,20 @@ done
 #test if the directory is a git
 git branch &> /dev/null || exit 3
 echo "Number of commits per author:"
-git --no-pager shortlog $END_AND_BEGIN  -sn --all
-AUTHORS=$(git shortlog $END_AND_BEGIN  -sn --all | cut -f2 | cut -f1 -d' ')
+git --no-pager shortlog "${END_AND_BEGIN[@]}" -sn --all
+AUTHORS=$(git shortlog "${END_AND_BEGIN[@]}" -sn --all | cut -f2 | cut -f1 -d' ')
 
 for a in $AUTHORS
 do
     echo '-------------------'
     echo "Statistics for: $a"
     echo -n "Number of files changed: "
-    git log "${LOGOPTS[@]}" $END_AND_BEGIN --all --numstat --format="%n" --author=$a | grep -v -e "^$" | cut -f3 | sort -iu | wc -l
+    git log "${LOGOPTS[@]}" "${END_AND_BEGIN[@]}" --all --numstat --format="%n" --author=$a | grep -v -e "^$" | cut -f3 | sort -iu | wc -l
     echo -n "Number of lines added: "
-    git log "${LOGOPTS[@]}" $END_AND_BEGIN --all --numstat --format="%n" --author=$a | cut -f1 | awk '{s+=$1} END {print s}'
+    git log "${LOGOPTS[@]}" "${END_AND_BEGIN[@]}" --all --numstat --format="%n" --author=$a | cut -f1 | awk '{s+=$1} END {print s}'
     echo -n "Number of lines deleted: "
-    git log "${LOGOPTS[@]}" $END_AND_BEGIN --all --numstat --format="%n" --author=$a | cut -f2 | awk '{s+=$1} END {print s}'
+    git log "${LOGOPTS[@]}" "${END_AND_BEGIN[@]}" --all --numstat --format="%n" --author=$a | cut -f2 | awk '{s+=$1} END {print s}'
     echo -n "Number of merges: "
-    git log "${LOGOPTS[@]}" $END_AND_BEGIN --all --merges --author=$a | grep -c '^commit'
+    git log "${LOGOPTS[@]}" "${END_AND_BEGIN[@]}" --all --merges --author=$a | grep -c '^commit'
 
 done

--- a/git-stats.sh
+++ b/git-stats.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-LOGOPTS=
+LOGOPTS=()
 END_AND_BEGIN=
 #argument parsing
 while [ -n "$1" ]; do
@@ -13,13 +13,14 @@ while [ -n "$1" ]; do
         END_AND_BEGIN="$END_AND_BEGIN --before=$1"
     ;;
     "-w")
-        LOGOPTS="$LOGOPTS -w"
+        LOGOPTS+=("-w")
     ;;
     "-C")
-        LOGOPTS="$LOGOPTS -C --find-copies-harder"
+        LOGOPTS+=("-C")
+		LOGOPTS+=("--find-copies-harder")
     ;;
     "-M")
-        LOGOPTS="$LOGOPTS -M"
+        LOGOPTS+=("-M")
     ;;
     esac
     shift
@@ -36,12 +37,12 @@ do
     echo '-------------------'
     echo "Statistics for: $a"
     echo -n "Number of files changed: "
-    git log $LOGOPTS $END_AND_BEGIN --all --numstat --format="%n" --author=$a | grep -v -e "^$" | cut -f3 | sort -iu | wc -l
+    git log "${LOGOPTS[@]}" $END_AND_BEGIN --all --numstat --format="%n" --author=$a | grep -v -e "^$" | cut -f3 | sort -iu | wc -l
     echo -n "Number of lines added: "
-    git log $LOGOPTS $END_AND_BEGIN --all --numstat --format="%n" --author=$a | cut -f1 | awk '{s+=$1} END {print s}'
+    git log "${LOGOPTS[@]}" $END_AND_BEGIN --all --numstat --format="%n" --author=$a | cut -f1 | awk '{s+=$1} END {print s}'
     echo -n "Number of lines deleted: "
-    git log $LOGOPTS $END_AND_BEGIN --all --numstat --format="%n" --author=$a | cut -f2 | awk '{s+=$1} END {print s}'
+    git log "${LOGOPTS[@]}" $END_AND_BEGIN --all --numstat --format="%n" --author=$a | cut -f2 | awk '{s+=$1} END {print s}'
     echo -n "Number of merges: "
-    git log $LOGOPTS $END_AND_BEGIN --all --merges --author=$a | grep -c '^commit'
+    git log "${LOGOPTS[@]}" $END_AND_BEGIN --all --merges --author=$a | grep -c '^commit'
 
 done


### PR DESCRIPTION
Converting global variables LOGOPTS and END_AND_BEGIN to arrays and expanding them properly inside double quotes to silencing the shellcheck warning 2086[1]. 
Same warning for the author variable extracted from git, just double quoting the use to silence the warnings.

[1]: https://github.com/koalaman/shellcheck/wiki/SC2086